### PR TITLE
Export unnormalized articulatory params for viewer

### DIFF
--- a/vocaltrax/synthesize.py
+++ b/vocaltrax/synthesize.py
@@ -39,7 +39,7 @@ from tqdm import tqdm
 from tract import VocalTract
 from utils.random import PRNGKey
 from utils.hydra import print_config
-from utils.misc import frameaudio, mse, jax_to_numpy
+from utils.misc import frameaudio, mse, jax_to_numpy, unnormalize_all_params
 
 config_store = hydra.core.config_store.ConfigStore.instance()
 config_store.store(name="base_config", node=Config)

--- a/vocaltrax/synthesize.py
+++ b/vocaltrax/synthesize.py
@@ -185,9 +185,17 @@ def main(cfg: Config) -> None:
                 os.path.join(log_dir, f"{i+1}.wav"), audio, sr
             )
 
-    # Save JAX params
-    with open(os.path.join(log_dir, "params.json"), "w") as f:
+    # Save normalized JAX params
+    with open(os.path.join(log_dir, "params_optimizer.json"), "w") as f:
         f.write(json.dumps(jax_to_numpy(params), indent=4))
+
+    # Save unnormalized params with frequencies for Pink Trombone
+    unnormalized_params = unnormalize_all_params(params['params'])
+    unnormalized_params['frequencies'] = freqs.tolist()
+
+    with open(os.path.join(log_dir, "params_pink_trombone.json"), "w") as f:
+        f.write(json.dumps(unnormalized_params, indent=4))
+
 
 if __name__ == "__main__":
     main()

--- a/vocaltrax/utils/misc.py
+++ b/vocaltrax/utils/misc.py
@@ -79,3 +79,50 @@ def jax_to_numpy(obj):
         return [jax_to_numpy(v) for v in obj]
     else:
         return obj
+
+def unnormalize_all_params(params):
+    unnormalized = {}
+
+    # Physical tract parameters
+    if 'physical' in params:
+        unnormalized['physical'] = {}
+        phys = params['physical']['params']
+
+        # Tongue parameters
+        if 'tongue' in phys:
+            unnormalized['physical']['tongue'] = {}
+            tongue = phys['tongue']['params']
+            if 'tongue_diam' in tongue:
+                unnormalized['physical']['tongue']['tongue_diam'] = jax_to_numpy(
+                    unnormalize_params(tongue['tongue_diam'], 2.05, 3.5)
+                )
+            if 'tongue_idx' in tongue:
+                unnormalized['physical']['tongue']['tongue_idx'] = jax_to_numpy(
+                    unnormalize_params(tongue['tongue_idx'], 12, 29)
+                )
+
+        # Throat constriction parameters
+        if 'throatconstriction' in phys:
+            unnormalized['physical']['throatconstriction'] = {}
+            throat = phys['throatconstriction']['params']
+            if 'constr_val' in throat:
+                unnormalized['physical']['throatconstriction']['constr_val'] = jax_to_numpy(
+                    1.5 - unnormalize_params(throat['constr_val'], -0.99, 0.99)
+                )
+
+        # Lip constriction parameters
+        if 'lipconstriction' in phys:
+            unnormalized['physical']['lipconstriction'] = {}
+            lip = phys['lipconstriction']['params']
+            if 'constr_val' in lip:
+                unnormalized['physical']['lipconstriction']['constr_val'] = jax_to_numpy(
+                    1.5 - unnormalize_params(lip['constr_val'], -0.99, 0.99)
+                )
+
+    # Tenseness parameters
+    if 'tenses' in params:
+        unnormalized['tenses'] = jax_to_numpy(
+            unnormalize_params(params['tenses'], 0.1, 1.0)
+        )
+
+    return unnormalized


### PR DESCRIPTION
This PR adds the functionality to save unnormalized articulatory parameters and frequencies to a `params_pink_trombone.json` file.

This export is required as input for an external GUI tool used to visualize the synthesis output.

The changes are self-contained and don't impact the existing optimization workflow.